### PR TITLE
refactor: vertical scrolling post list

### DIFF
--- a/src/components/PostCard/styles.ts
+++ b/src/components/PostCard/styles.ts
@@ -3,25 +3,38 @@ import styled from "styled-components";
 export const Container = styled.div`
   position: relative;
   width: 100%;
+  min-height: 400px;
   border-radius: 20px;
   background-color: rgb(222, 246, 255);
-  padding: 30px 20px;
+  padding: 20px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
+  align-items: center;
   text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    min-height: 350px;
+  }
+
+  @media (max-width: 480px) {
+    min-height: 300px;
+    padding: 15px;
+  }
 `;
 
 export const PostContent = styled.div`
   font-size: 20px;
-  font-weight: bold;
+  font-weight: 500;
   color: #333;
-  word-wrap: break-word;
   word-break: break-word;
   white-space: pre-wrap;
   text-align: center;
+  padding: 0 20px;
+  max-width: 100%;
 `;
 
 export const UserPostInfo = styled.div`
@@ -30,18 +43,20 @@ export const UserPostInfo = styled.div`
   bottom: 20px;
   display: flex;
   align-items: center;
-  font-size: 12px;
+  font-size: 13px;
 
   img {
     width: 30px;
     height: 30px;
-    opacity: 0.8;
+    border-radius: 50%;
+    opacity: 0.85;
     margin-right: 10px;
   }
 
   h3 {
     margin: 0;
     font-weight: normal;
+    font-size: 14px;
   }
 
   @media (max-width: 480px) {
@@ -53,5 +68,5 @@ export const Actions = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  margin-top: 10px;
+  margin-top: 15px;
 `;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { AnimatePresence } from "framer-motion";
 import { Container, TextPost, BoxPost, IconButton, UserTop } from "./styles";
 
 import User from "../../components/User";
@@ -8,7 +7,6 @@ import DownIcon from "../../assets/down.svg";
 
 const Home = () => {
   const [posts, setPosts] = useState<{ content: string }[]>([]);
-  const [currentPostIndex, setCurrentPostIndex] = useState(0);
   const [newPost, setNewPost] = useState("");
   const [likedPosts, setLikedPosts] = useState<boolean[]>([]);
 
@@ -18,14 +16,6 @@ const Home = () => {
       setPosts([newPostObject, ...posts]);
       setLikedPosts([false, ...likedPosts]);
       setNewPost("");
-    }
-  };
-
-  const handleScroll = (event: React.WheelEvent) => {
-    if (event.deltaY > 0 && currentPostIndex < posts.length - 1) {
-      setCurrentPostIndex(currentPostIndex + 1);
-    } else if (event.deltaY < 0 && currentPostIndex > 0) {
-      setCurrentPostIndex(currentPostIndex - 1);
     }
   };
 
@@ -53,17 +43,17 @@ const Home = () => {
         </IconButton>
       </TextPost>
 
-      <BoxPost onWheel={handleScroll}>
+      <BoxPost>
         {posts.length > 0 ? (
-          <AnimatePresence mode="wait">
+          posts.map((post, index) => (
             <PostCard
-              key={currentPostIndex}
-              content={posts[currentPostIndex].content}
+              key={index}
+              content={post.content}
               userName="Nome do Usuário"
-              liked={likedPosts[currentPostIndex]}
-              onClick={() => toggleLike(currentPostIndex)}
+              liked={likedPosts[index]}
+              onClick={() => toggleLike(index)}
             />
-          </AnimatePresence>
+          ))
         ) : (
           <p>Nenhum Post ainda, crie seu primeiro!</p>
         )}

--- a/src/pages/Home/styles.ts
+++ b/src/pages/Home/styles.ts
@@ -108,7 +108,3 @@ export const UserTop = styled.div`
   top: 20px;
   z-index: 1000;
 `;
-
-export const DotNavigation = styled.div`
-  display: none;
-`;

--- a/src/pages/Home/styles.ts
+++ b/src/pages/Home/styles.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -14,13 +15,13 @@ export const Container = styled.div`
 
 export const TextPost = styled.div`
   width: 100%;
-  max-width: 300px;
+  max-width: 500px;
   margin-bottom: 20px;
   position: relative;
 
   textarea {
     width: 100%;
-    height: 45px;
+    height: 60px;
     border-radius: 8px;
     padding: 10px;
     font-size: 16px;
@@ -39,7 +40,7 @@ export const TextPost = styled.div`
 
   @media (max-width: 480px) {
     margin-top: 100px;
-    max-width: 60%;
+    max-width: 90%;
   }
 `;
 
@@ -73,28 +74,29 @@ export const IconButton = styled.button`
 export const BoxPost = styled.div`
   width: 100%;
   max-width: 600px;
-  min-height: 400px;
-  height: auto;
+  height: 75vh;
   border-radius: 20px;
-  background-color: rgb(222, 246, 255);
+  background-color: transparent;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 20px;
+  flex-direction: column;
+  gap: 32px;
+  overflow-y: scroll;
+  padding: 10px;
   box-sizing: border-box;
-  position: relative;
 
-  p {
-    color: #aaa;
+  &::-webkit-scrollbar {
+    display: none;
   }
+
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 
   @media (max-width: 768px) {
     max-width: 90%;
   }
 
   @media (max-width: 480px) {
-    max-width: 70%;
+    max-width: 100%;
   }
 `;
 
@@ -105,4 +107,8 @@ export const UserTop = styled.div`
   position: fixed;
   top: 20px;
   z-index: 1000;
+`;
+
+export const DotNavigation = styled.div`
+  display: none;
 `;


### PR DESCRIPTION
🚀Refatorar feed de posts para layout vertical

-  Removido o scroll por wheel e a navegação por índice de post.

- Implementado scroll vertical natural com todos os posts listados.

- Ajustado o componente PostCard para exibir os posts com altura fixa, espaçamento mais amplo.

-  Removida a simulação de carregamento automático de posts, deixando o estado de posts dependente apenas da adição manual (e futuramente da API).

🧪 Como testar
Acesse a tela Home.

Escreva algo no textarea e clique no botão de postar.

Verifique que os posts são adicionados em ordem e exibidos um embaixo do outro.

Teste diferentes tamanhos de texto (curto e longo) para garantir o comportamento esperado do layout.

A rolagem da página deve funcionar normalmente, sem navegação por rolagem do mouse entre os posts.

📌 Observações
Em breve será aplicado a API de posts reais.

O layout responsivo também foi mantido para diferentes tamanhos de tela.