### PR TITLE
feat: add like and comment buttons to post card

### DIFF
--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -6,4 +6,5 @@ export {
   Mail,
   LockKeyhole,
   UserRound,
+  MessageSquareText,
 } from "lucide-react";

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -1,0 +1,19 @@
+import { MessageSquareText } from "lucide-react";
+import { Button } from "./styles";
+import { motion } from "framer-motion";
+
+interface CommentButtonProps {
+  onClick?: () => void;
+}
+
+const CommentButton = ({ onClick }: CommentButtonProps) => {
+  return (
+    <Button onClick={onClick}>
+      <motion.div whileTap={{ scale: 0.9 }} whileHover={{ scale: 1.1 }}>
+        <MessageSquareText size={28} strokeWidth={2} />
+      </motion.div>
+    </Button>
+  );
+};
+
+export default CommentButton;

--- a/src/components/Comment/styles.ts
+++ b/src/components/Comment/styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const Button = styled.button<{ liked: boolean }>`
+export const Button = styled.button`
   background: none;
   border: none;
   cursor: pointer;
@@ -11,11 +11,11 @@ export const Button = styled.button<{ liked: boolean }>`
   svg {
     width: 28px;
     height: 28px;
-    opacity: ${(props) => (props.liked ? 1 : 0.8)};
-    display: block;
+    color: ${({ theme }) => theme.colors.gray[900]};
+    opacity: 0.85;
   }
 
-  @media (max-width: 480px) {
-    right: -40px;
+  &:hover svg {
+    opacity: 1;
   }
 `;

--- a/src/components/LikeButton/index.tsx
+++ b/src/components/LikeButton/index.tsx
@@ -15,7 +15,7 @@ const LikeButton = ({ liked, onClick }: LikeButtonProps) => {
     <Button onClick={onClick} liked={liked}>
       <motion.div whileTap={{ scale: 0.9 }} whileHover={{ scale: 1.1 }}>
         <Heart
-          size={30}
+          size={25}
           color={liked ? "red" : theme.colors.gray[1000]}
           fill={liked ? "red" : "none"}
         />

--- a/src/components/PostCard/index.tsx
+++ b/src/components/PostCard/index.tsx
@@ -1,7 +1,8 @@
 import { motion } from "framer-motion";
-import { Container, PostContent, UserPostInfo } from "./styles";
+import { Container, PostContent, UserPostInfo, PostActions } from "./styles";
 import Avatar from "../Avatar";
 import LikeButton from "../LikeButton";
+import Comment from "../Comment";
 
 interface PostCardProps {
   content: string;
@@ -22,12 +23,19 @@ const PostCard = ({ content, userName, liked, onClick }: PostCardProps) => {
         <PostContent>{content}</PostContent>
       </motion.div>
 
-      <LikeButton liked={liked} onClick={onClick} />
-
       <UserPostInfo>
         <Avatar name={userName} />
         <h3>{userName}</h3>
       </UserPostInfo>
+
+      <PostActions>
+        <div className="action-button like">
+          <LikeButton liked={liked} onClick={onClick} />
+        </div>
+        <div className="action-button comment">
+          <Comment />
+        </div>
+      </PostActions>
     </Container>
   );
 };

--- a/src/components/PostCard/styles.ts
+++ b/src/components/PostCard/styles.ts
@@ -26,6 +26,20 @@ export const Container = styled.div`
   }
 `;
 
+export const PostActions = styled.div`
+  position: absolute;
+  right: 100px;
+  bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+
+  @media (max-width: 480px) {
+    right: 10px;
+    gap: 15px;
+  }
+`;
+
 export const PostContent = styled.div`
   font-size: 16px;
   font-weight: 500;


### PR DESCRIPTION
🛑 Problema
Os posts ainda não tinham interações visuais como curtir ou comentar.

🔧 Solução
Adicionei os botões de curtir e comentar no componente PostCard, o botão de like muda de cor ao clicar, e ambos estão posicionados visualmente ao lado inferior direito do card.